### PR TITLE
Initial RBAC support: create and use K8s service account for Redis

### DIFF
--- a/pkg/controller/dormant_database.go
+++ b/pkg/controller/dormant_database.go
@@ -25,6 +25,19 @@ func (c *Controller) WaitUntilPaused(drmn *api.DormantDatabase) error {
 		return err
 	}
 
+	if err := c.waitUntilRBACStuffDeleted(db.ObjectMeta); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Controller) waitUntilRBACStuffDeleted(meta metav1.ObjectMeta) error {
+	// Delete ServiceAccount
+	if err := core_util.WaitUntillServiceAccountDeleted(c.Client, meta); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/controller/rbac.go
+++ b/pkg/controller/rbac.go
@@ -1,0 +1,42 @@
+package controller
+
+import (
+	core_util "github.com/appscode/kutil/core/v1"
+	api "github.com/kubedb/apimachinery/apis/kubedb/v1alpha1"
+	core "k8s.io/api/core/v1"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/reference"
+)
+
+func (c *Controller) createServiceAccount(redis *api.Redis) error {
+	ref, rerr := reference.GetReference(clientsetscheme.Scheme, redis)
+	if rerr != nil {
+		return rerr
+	}
+	// Create new ServiceAccount
+	_, _, err := core_util.CreateOrPatchServiceAccount(
+		c.Client,
+		metav1.ObjectMeta{
+			Name:      redis.OffshootName(),
+			Namespace: redis.Namespace,
+		},
+		func(in *core.ServiceAccount) *core.ServiceAccount {
+			core_util.EnsureOwnerReference(&in.ObjectMeta, ref)
+			return in
+		},
+	)
+	return err
+}
+
+func (c *Controller) ensureRBACStuff(redis *api.Redis) error {
+	// Create New ServiceAccount
+	if err := c.createServiceAccount(redis); err != nil {
+		if !kerr.IsAlreadyExists(err) {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/statefulset.go
+++ b/pkg/controller/statefulset.go
@@ -156,6 +156,11 @@ func (c *Controller) createStatefulSet(redis *api.Redis) (*apps.StatefulSet, kut
 		in.Spec.UpdateStrategy = redis.Spec.UpdateStrategy
 		in = upsertUserEnv(in, redis)
 		in = upsertCustomConfig(in, redis)
+
+		if c.EnableRBAC {
+			in.Spec.Template.Spec.ServiceAccountName = redis.OffshootName()
+		}
+
 		return in
 	})
 }


### PR DESCRIPTION
Redis runs with a dedicated service account instead of default.
Can be handy in case one wants to bind the service account
to a pod security policy (PSP) role binding.